### PR TITLE
added Graymill Pelican theme to Milligram Themes list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Milligram provides a minimal setup of styles for a fast and clean starting point
 ## Themes
 - [Millikyl](https://github.com/fareez-ahamed/millikyl)
 - [MilliGrav](https://github.com/moreplavec/MilliGrav)
+- [Graymill - a Pelican theme](https://github.com/rn4ir/graymill)
 
 
 ## Boilerplates/Kits/Starters


### PR DESCRIPTION
Added a new Pelican theme, based on the Milligram CSS Framework. Available in the [official Pelican themes repo](https://github.com/getpelican/pelican-themes/tree/master/graymill) too.